### PR TITLE
Add the ability for a user to be an admin (and rooms of company api endpoint)

### DIFF
--- a/libs/api/rooms/api/src/lib/api-rooms-api.controller.ts
+++ b/libs/api/rooms/api/src/lib/api-rooms-api.controller.ts
@@ -14,4 +14,9 @@ export class ApiRoomsApiController {
     async getRoomById(@Param('id') id: string) {
         return await this.roomService.getRoomById(Number(id));
     }
+
+    @Get('/company/:companyId')
+    async getRoomsByCompanyId(@Param('companyId') companyId: string) {
+        return await this.roomService.getRoomsByCompanyId(Number(companyId));
+    }
 }

--- a/libs/api/rooms/repository/data-access/src/lib/api-rooms-repository-data-access.service.ts
+++ b/libs/api/rooms/repository/data-access/src/lib/api-rooms-repository-data-access.service.ts
@@ -18,4 +18,12 @@ export class ApiRoomsRepositoryDataAccessService {
             },
         });
     }
+
+    async getRoomsByCompanyId(companyId: number) {
+        return this.prisma.room.findMany({
+            where: {
+                companyId: companyId,
+            },
+        });
+    }
 }

--- a/libs/api/users/api/src/lib/api-users-api.controller.spec.ts
+++ b/libs/api/users/api/src/lib/api-users-api.controller.spec.ts
@@ -49,7 +49,8 @@ describe('ApiUsersApiController', () => {
     const postData = {
       name: 'ying',
       companyId: 2,
-      email: 'email'
+      email: 'email',
+      admin: false
     }
     controller.createUser(postData);
     expect(service.createUser).toHaveBeenCalledWith({
@@ -59,7 +60,8 @@ describe('ApiUsersApiController', () => {
           id: 2,
         }
       },
-      email: 'email'
+      email: 'email',
+      admin: false
     });
   })
 

--- a/libs/api/users/api/src/lib/api-users-api.controller.ts
+++ b/libs/api/users/api/src/lib/api-users-api.controller.ts
@@ -48,6 +48,7 @@ export class ApiUsersApiController {
                 },
             },
             email: email,
+            admin: false,
         });
     }
 

--- a/prisma/migrations/20220607093101_/migration.sql
+++ b/prisma/migrations/20220607093101_/migration.sql
@@ -12,6 +12,7 @@ CREATE TABLE "Employee" (
     "name" TEXT NOT NULL,
     "email" TEXT NOT NULL,
     "companyId" INTEGER NOT NULL,
+    "admin" BOOLEAN NOT NULL,
 
     CONSTRAINT "Employee_pkey" PRIMARY KEY ("id")
 );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model Employee {
   company   Company   @relation(fields: [companyId], references: [id])
   Bookings  Booking[]
   companyId Int
+  admin     Boolean
 }
 
 // model the structure of the office

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,17 +11,19 @@ async function main() {
 
     const employee1 = await prisma.employee.create({
         data: {
-            name: 'Steve Jobs',
+            name: 'Kryptos Kode',
             company: { connect: { id: company.id } },
-            email: 'stevejobs@apple.com',
+            email: 'kryptoskode301@gmail.com',
+            admin: true,
         },
     })
 
     const employee2 = await prisma.employee.create({
         data: {
-            name: 'Bill Gates',
+            name: 'Brett du Plessis',
             company: { connect: { id: company.id } },
-            email: 'billgates@apple.com',
+            email: 'duplessisbrett@icloud.com',
+            admin: false,
         },
     })
 


### PR DESCRIPTION
The user/employee model now contains a simple admin boolean flag to determine whether or not they are an admin.

For now, a newly created user via the createUser endpoint is NOT an admin by default

closes #146 

This PR also addresses #122 because I accidentally pushed to the wrong branch