### PR TITLE
Add a basic permission service

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -12,6 +12,7 @@
     "api-facilities-api": "libs/api/facilities/api",
     "api-facilities-repository-data-access": "libs/api/facilities/repository/data-access",
     "api-interfaces": "libs/api-interfaces",
+    "api-permissions": "libs/api/permissions/",
     "api-rooms-api": "libs/api/rooms/api",
     "api-rooms-repository-data-access": "libs/api/rooms/repository/data-access",
     "api-shared-services-prisma-data-access": "libs/api/shared/services/prisma/data-access",

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -17,12 +17,13 @@ import { AppService } from './app.service';
 import { ApiCompaniesRepositoryDataAccessService } from '@office-booker/api/companies/repository/data-access';
 import { ApiUsersRepositoryDataAccessService } from '@office-booker/api/users/repository/data-access';
 import { ApiAuthorizationModule } from '@office-booker/api/authorization';
+import { ApiPermissionsService } from '@office-booker/api/permissions';
 
 @Module({
   imports: [ApiAuthorizationModule, ConfigModule.forRoot({
     isGlobal: true,
   })],
   controllers: [AppController, ApiRoomsApiController, ApiDesksApiController, ApiFacilitiesApiController, ApiBookingsApiController, ApiCompaniesApiController, ApiUsersApiController],
-  providers: [AppService, PrismaService, ApiRoomsRepositoryDataAccessService, ApiDesksRepositoryDataAccessService, ApiFacilitiesRepositoryDataAccessService, ApiBookingsRepositoryDataAccessService, ApiCompaniesRepositoryDataAccessService, ApiUsersRepositoryDataAccessService],
+  providers: [AppService, PrismaService, ApiRoomsRepositoryDataAccessService, ApiDesksRepositoryDataAccessService, ApiFacilitiesRepositoryDataAccessService, ApiBookingsRepositoryDataAccessService, ApiCompaniesRepositoryDataAccessService, ApiUsersRepositoryDataAccessService, ApiPermissionsService],
 })
 export class AppModule {}

--- a/libs/api/bookings/api/src/lib/api-bookings-api.controller.spec.ts
+++ b/libs/api/bookings/api/src/lib/api-bookings-api.controller.spec.ts
@@ -1,6 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ApiBookingsRepositoryDataAccessService } from '@office-booker/api/bookings/repository/data-access';
+import { ApiCompaniesRepositoryDataAccessService } from '@office-booker/api/companies/repository/data-access';
+import { ApiDesksRepositoryDataAccessService } from '@office-booker/api/desks/repository/data-access';
+import { ApiPermissionsService } from '@office-booker/api/permissions';
+import { ApiRoomsRepositoryDataAccessService } from '@office-booker/api/rooms/repository/data-access';
 import { PrismaService } from '@office-booker/api/shared/services/prisma/data-access';
+import { ApiUsersRepositoryDataAccessService } from '@office-booker/api/users/repository/data-access';
 import { ApiBookingsApiController } from './api-bookings-api.controller';
 
 describe('ApiBookingsApiController', () => {
@@ -8,7 +13,7 @@ describe('ApiBookingsApiController', () => {
   let service: ApiBookingsRepositoryDataAccessService;
   beforeAll(async () => {
     const ApiServiceProvider = {
-      provide: ApiBookingsRepositoryDataAccessService,
+      provide: ApiBookingsRepositoryDataAccessService, ApiPermissionsService, ApiDesksRepositoryDataAccessService, ApiRoomsRepositoryDataAccessService, ApiCompaniesRepositoryDataAccessService, ApiUsersRepositoryDataAccessService,
       useFactory: () => ({
         getBookingsForDesk: jest.fn(() => []),
         getBookingById: jest.fn(() => ({})),
@@ -19,7 +24,7 @@ describe('ApiBookingsApiController', () => {
     }
     const app: TestingModule = await Test.createTestingModule({
       controllers: [ApiBookingsApiController],
-      providers: [ApiBookingsRepositoryDataAccessService, ApiServiceProvider],
+      providers: [ApiBookingsRepositoryDataAccessService, ApiServiceProvider, ApiPermissionsService, ApiDesksRepositoryDataAccessService, ApiRoomsRepositoryDataAccessService, ApiCompaniesRepositoryDataAccessService, ApiUsersRepositoryDataAccessService, PrismaService],
     }).compile();
     controller = app.get<ApiBookingsApiController>(ApiBookingsApiController);
     service = app.get<ApiBookingsRepositoryDataAccessService>(ApiBookingsRepositoryDataAccessService);

--- a/libs/api/desks/repository/data-access/src/lib/api-desks-repository-data-access.service.ts
+++ b/libs/api/desks/repository/data-access/src/lib/api-desks-repository-data-access.service.ts
@@ -18,4 +18,13 @@ export class ApiDesksRepositoryDataAccessService {
             }, 
         });
     }
+
+    // get a specific desk by its id
+    async getDeskById(deskId: number) {
+        return this.prisma.desk.findUnique({
+            where: {
+                id: deskId,
+            },
+        });
+    }
 }

--- a/libs/api/permissions/.eslintrc.json
+++ b/libs/api/permissions/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/api/permissions/README.md
+++ b/libs/api/permissions/README.md
@@ -1,0 +1,7 @@
+# api-permissions-
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test api-permissions-` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/api/permissions/jest.config.ts
+++ b/libs/api/permissions/jest.config.ts
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'api-permissions-',
+  preset: '../../../jest.preset.ts',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/api/permissions/',
+};

--- a/libs/api/permissions/project.json
+++ b/libs/api/permissions/project.json
@@ -1,0 +1,22 @@
+{
+  "root": "libs/api/permissions/",
+  "sourceRoot": "libs/api/permissions/src",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/api/permissions//**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/api/permissions/"],
+      "options": {
+        "jestConfig": "libs/api/permissions/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/api/permissions/src/index.ts
+++ b/libs/api/permissions/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/api-permissions.service';
+export * from './lib/api-permissions.module';

--- a/libs/api/permissions/src/lib/api-permissions.module.ts
+++ b/libs/api/permissions/src/lib/api-permissions.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ApiPermissionsService } from './api-permissions.service';
+
+@Module({
+  controllers: [],
+  providers: [ApiPermissionsService],
+  exports: [ApiPermissionsService],
+})
+export class ApiPermissionsModule {}

--- a/libs/api/permissions/src/lib/api-permissions.service.spec.ts
+++ b/libs/api/permissions/src/lib/api-permissions.service.spec.ts
@@ -1,12 +1,17 @@
 import { Test } from '@nestjs/testing';
-import { ApiPermissionsService } from './api-permissions-.service';
+import { ApiCompaniesRepositoryDataAccessService } from '@office-booker/api/companies/repository/data-access';
+import { ApiDesksRepositoryDataAccessService } from '@office-booker/api/desks/repository/data-access';
+import { ApiRoomsRepositoryDataAccessService } from '@office-booker/api/rooms/repository/data-access';
+import { PrismaService } from '@office-booker/api/shared/services/prisma/data-access';
+import { ApiUsersRepositoryDataAccessService } from '@office-booker/api/users/repository/data-access';
+import { ApiPermissionsService } from './api-permissions.service';
 
 describe('ApiPermissionsService', () => {
   let service: ApiPermissionsService;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      providers: [ApiPermissionsService],
+      providers: [ApiPermissionsService, ApiUsersRepositoryDataAccessService, ApiCompaniesRepositoryDataAccessService, ApiDesksRepositoryDataAccessService, ApiRoomsRepositoryDataAccessService, PrismaService],
     }).compile();
 
     service = module.get(ApiPermissionsService);

--- a/libs/api/permissions/src/lib/api-permissions.service.spec.ts
+++ b/libs/api/permissions/src/lib/api-permissions.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test } from '@nestjs/testing';
+import { ApiPermissionsService } from './api-permissions-.service';
+
+describe('ApiPermissionsService', () => {
+  let service: ApiPermissionsService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [ApiPermissionsService],
+    }).compile();
+
+    service = module.get(ApiPermissionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/api/permissions/src/lib/api-permissions.service.ts
+++ b/libs/api/permissions/src/lib/api-permissions.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, Param } from '@nestjs/common';
+import { ApiCompaniesRepositoryDataAccessService } from '@office-booker/api/companies/repository/data-access';
+import { ApiDesksRepositoryDataAccessService } from '@office-booker/api/desks/repository/data-access';
+import { ApiRoomsRepositoryDataAccessService } from '@office-booker/api/rooms/repository/data-access';
+import { ApiUsersRepositoryDataAccessService } from '@office-booker/api/users/repository/data-access';
+
+@Injectable()
+export class ApiPermissionsService {
+    constructor(private userService: ApiUsersRepositoryDataAccessService,
+        private deskService: ApiDesksRepositoryDataAccessService,
+        private roomService: ApiRoomsRepositoryDataAccessService,
+        private companyService: ApiCompaniesRepositoryDataAccessService) {}
+
+
+    async userAndDesk(@Param() userId: number, @Param() deskId: number) : Promise<boolean> {
+        const user = await this.userService.getUserById(userId);
+        const desk = await this.deskService.getDeskById(deskId);
+        const room = await this.roomService.getRoomById(desk.roomId);
+        const company = await this.companyService.getCompanyById(room.companyId);
+        // console.log("user and desk companies match!")
+        return user.companyId === company.id;
+    }
+}

--- a/libs/api/permissions/tsconfig.json
+++ b/libs/api/permissions/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/api/permissions/tsconfig.lib.json
+++ b/libs/api/permissions/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": [],
+    "target": "es6"
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/libs/api/permissions/tsconfig.spec.json
+++ b/libs/api/permissions/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/prisma/migrations/20220609104623_init/migration.sql
+++ b/prisma/migrations/20220609104623_init/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - Made the column `employeeId` on table `Booking` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `companyId` on table `Room` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Booking" DROP CONSTRAINT "Booking_employeeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Room" DROP CONSTRAINT "Room_companyId_fkey";
+
+-- AlterTable
+ALTER TABLE "Booking" ALTER COLUMN "employeeId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Room" ALTER COLUMN "companyId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Room" ADD CONSTRAINT "Room_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Booking" ADD CONSTRAINT "Booking_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "Employee"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,8 +33,8 @@ model Room {
   id        Int      @id @default(autoincrement())
   name      String
   desks     Desk[]
-  Company   Company? @relation(fields: [companyId], references: [id])
-  companyId Int?
+  Company   Company @relation(fields: [companyId], references: [id])
+  companyId Int
 }
 
 model Desk {
@@ -64,6 +64,6 @@ model Booking {
   createdAt  DateTime  @default(now())
   startsAt   DateTime
   endsAt     DateTime
-  Employee   Employee? @relation(fields: [employeeId], references: [id])
-  employeeId Int?
+  Employee   Employee @relation(fields: [employeeId], references: [id])
+  employeeId Int
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -39,6 +39,7 @@
       "@office-booker/api/facilities/repository/data-access": [
         "libs/api/facilities/repository/data-access/src/index.ts"
       ],
+      "@office-booker/api/permissions": ["libs/api/permissions/src/index.ts"],
       "@office-booker/api/rooms/api": ["libs/api/rooms/api/src/index.ts"],
       "@office-booker/api/rooms/repository/data-access": [
         "libs/api/rooms/repository/data-access/src/index.ts"


### PR DESCRIPTION
This PR add a basic permission service, which for the time being is being used to check new bookings made.

Specifically it checks that the user making the booking belongs to the same company that the desk belongs to.