### PR TITLE
🐛 (bookings): overlap with exact times

### DIFF
--- a/apps/office-booker/src/app/bookings/map-bookings/map-bookings.component.ts
+++ b/apps/office-booker/src/app/bookings/map-bookings/map-bookings.component.ts
@@ -192,13 +192,13 @@ export class MapBookingsComponent{
     currentDesk[0].bookings.forEach(booking => {        //goes through all the bookings for the currently selected desk
       const endDateCheck = new Date(booking.endsAt);      //conversions needed for comparison
       const startDateCheck = new Date(booking.startsAt);
-      if(endDateCheck > startDate && startDateCheck < startDate){       //if the booking end date is greater than the start of the attempted start booking date and start date of booking is less than the attempted start booking date
+      if(endDateCheck >= startDate && startDateCheck <= startDate){       //if the booking end date is greater than the start of the attempted start booking date and start date of booking is less than the attempted start booking date
         bookingClash = true;                                            //ie if the attempted booking date starts before the end of a booking but after the start of the same booking
       }
-      else if(startDateCheck < endDate && endDateCheck > endDate){      //if the booking start date is less than the end of the attempted end booking date and the end date is greater than the end of the attempted end booking date
+      else if(startDateCheck <= endDate && endDateCheck >= endDate){      //if the booking start date is less than the end of the attempted end booking date and the end date is greater than the end of the attempted end booking date
         bookingClash = true;                                            //ie if the attempted booking date ends after the start of a booking but before the end of the same booking 
       }
-      else if (startDate < startDateCheck && endDate > endDateCheck){     // if the start of the attempted start booking date is less than the start date of the booking and the end of attempted booking end date is greater than the end date of the booking
+      else if (startDate <= startDateCheck && endDate >= endDateCheck){     // if the start of the attempted start booking date is less than the start date of the booking and the end of attempted booking end date is greater than the end date of the booking
         bookingClash = true;                                               //ie when the start of the attempted booking date is before the start of an existing booking and the end of the attempted booking date is after end date the of the same existing booking
       }
     })


### PR DESCRIPTION
Minor fix for overlapping bookings when times are exact